### PR TITLE
정답 비교 시, 텍스트 전체의 양 끝 공백만 제거하도록 수정

### DIFF
--- a/src/utils/testCaseRunner.ts
+++ b/src/utils/testCaseRunner.ts
@@ -116,10 +116,7 @@ async function runCode(filePath: string, inputData: string): Promise<string> {
             clearTimeout(timeout);
             if (code === 0) {
                 resolve(
-                    output
-                        .split('\n')
-                        .map(line => line.trim())
-                        .join('\n').trim()
+                    output.trim()
                 );
             } else {
                 reject(new Error(error || `Process exited with code ${code}`));

--- a/src/utils/testCaseRunner.ts
+++ b/src/utils/testCaseRunner.ts
@@ -116,7 +116,11 @@ async function runCode(filePath: string, inputData: string): Promise<string> {
             clearTimeout(timeout);
             if (code === 0) {
                 resolve(
-                    output.trim()
+                    output
+                        .split('\n')
+                        .map(line => line.trimEnd())
+                        .join('\n')
+                        .trim()
                 );
             } else {
                 reject(new Error(error || `Process exited with code ${code}`));


### PR DESCRIPTION
## 작업 내용*
- 수정 전 : 표준 출력 문자열 각 라인마다 양 끝 공백을 제거
- 수정 후 : 표준 출력 문자열 전체의 양 끝 공백만 제거하도록 수정

## 작업 설명*
- [10171번: 고양이](https://www.acmicpc.net/problem/10171), [2446번: 별찍기](https://www.acmicpc.net/problem/2446)와 같이 공백이 중요한 문제에서 이전 비교 방식이 문제를 일으킵니다.

## 스크린샷
<img width="327" alt="스크린샷 2025-02-08 오후 10 28 24" src="https://github.com/user-attachments/assets/c9b6978a-6fe8-46d9-ba81-2a2d75ee63e6" />
<img width="316" alt="스크린샷 2025-02-08 오후 10 26 37" src="https://github.com/user-attachments/assets/0b4a0fab-0ef2-4c05-a320-469f5e435aa8" />
