### PR TITLE
[macOS] 환경변수 채점 이슈 - 항상 zsh 쉘의 환경 변수 적용되도록 수정

### DIFF
--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,0 +1,26 @@
+import { execSync, spawn } from 'child_process';
+
+class ChildProcess {
+    private env: NodeJS.ProcessEnv = process.env;
+
+    constructor(){
+        if(process.platform === 'darwin') {
+            const zshShellPathEnv = execSync('zsh -i -c "printenv"', { encoding: 'utf-8'})
+                .split('\n')
+                .map((line) => line.split('='))
+                .filter(([key]) => key === 'PATH').pop();
+
+            if(zshShellPathEnv) {
+                this.env['PATH'] += `:${zshShellPathEnv[1]}`;
+            }
+        }
+    }
+
+    spawn(command: string, args: string[] = []){
+        return spawn(command, args, {
+            env: this.env
+        });
+    }
+}
+
+export const childProcess = new ChildProcess();

--- a/src/utils/testCaseRunner.ts
+++ b/src/utils/testCaseRunner.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as childProcess from 'child_process';
+import { childProcess } from './process';
 import { Problem } from '../types';
 import path from 'path';
 const outputChannel = vscode.window.createOutputChannel('Test Results');


### PR DESCRIPTION
## 작업 내용*
- **환경변수 누락**으로 인한 **채점 오류**가 발생하지 않도록, 채점에 사용되는 프로세스 함수 `spawn`에 올바르게 된 환경변수가 일괄적으로 적용되도록 수정해보았습니다.
- zsh 쉘의 환경변수를 읽어와 spawn 함수를 실행할 때 추가적으로 전달해줍니다.

## 작업 설명*
### 환경
- macOS Sequoia 15.3
- vscode 1.96

### 문제 상황
<img width="411" alt="image" src="https://github.com/user-attachments/assets/75328c11-e191-4ca6-a14d-2e3d4a5ada60" />

- **다시 로그인하면 윈도우 다시 열기**에 의해 vscode가 실행 될 경우, 환경변수 누락으로 인해 채점 오류가 발생합니다.
- macOS 기본 컴파일러/인터프리터 `python3`, `g++` 등을 제외한 컴파일러/인터프리터(예 - `node.js`)가 해당

### 문제 원인
- mac 환경에서 vscode를 실행하면 기본 쉘(macOS Catalina 10.15 이후 기준)`zsh` 쉘이 사용됩니다. 
- 하지만 **다시 로그인하면 윈도우 다시 열기**에 의해 vscode가 실행 될 경우, 기본 `zsh` 쉘이 아닌 `sh` 쉘로 동작하게 되며, 사용자가 설정한 환경 변수가 적용되지 않습니다.

### 문제 재현 방법 
1. vscode를 실행합니다.
2. 컴퓨터를 종료 혹은 재부팅 시 "다시 로그인하면 윈도우 다시 열기"에 체크합니다.
3. 부팅이 완료되고 자동으로 실행 된 vscode에서 환경변수 누락으로 인해 기능이 동작하지 않습니다.
    1. macOS 기본 인터프리터/컴파일러가 아닌 언어의 런타임 환경으로 테스트하셔야 합니다. (예 - `node.js`)

## 스크린샷
<img width="323" alt="image" src="https://github.com/user-attachments/assets/b8a6f118-08aa-4a4a-a8ec-d49150b20c95" />
<img width="911" alt="스크린샷 2025-02-10 오후 2 52 09" src="https://github.com/user-attachments/assets/65041931-b7bb-4b54-bc98-3920427042b0" />