### PR TITLE
Fix : $로 감싼 수식이 올바르게 표시되도록 MathJax 설정 파일 수정

### DIFF
--- a/media/mathjax.js
+++ b/media/mathjax.js
@@ -1,0 +1,47 @@
+window.MathJax = {
+    tex: {
+        inlineMath: [ ['$', '$'], ['\\(', '\\)'] ],
+        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+        processEscapes: true,
+        tags: "ams",
+        autoload: {
+            color: [],
+            colorv2: ['color']
+        },
+        packages: { '[+]': ['noerrors', 'configmacros'] },
+        macros: {
+            class: " ",
+            style: " ",
+            href: " ",
+        }
+    },
+    options: {
+        ignoreHtmlClass: "no-mathjax|redactor-editor|redactor-box",
+        processHtmlClass: 'mathjax',
+        enableMenu: false,
+    },
+    chtml: {
+        scale: 0.9
+    },
+    loader: {
+        load: ['input/tex', 'output/chtml', '[tex]/noerrors'],
+    },
+    startup: {
+        ready() {
+            const {newState, STATE} = MathJax._.core.MathItem;
+            const {AbstractMathDocument} = MathJax._.core.MathDocument;
+            const {CHTML} = MathJax._.output.chtml_ts;
+            newState('ADDTEXT', 156);
+            AbstractMathDocument.ProcessBits.allocate('addtext');
+            CHTML.commonStyles['mjx-copytext'] = {
+                display: 'inline-block',
+                position: 'absolute',
+                top: 0, left: 0, width: 0, height: 0,
+                opacity: 0,
+                overflow: 'hidden'
+            };
+            MathJax.STATE = STATE;
+            MathJax.startup.defaultReady();
+        }
+    }
+};

--- a/src/panels/problemInfoPanel.ts
+++ b/src/panels/problemInfoPanel.ts
@@ -126,6 +126,7 @@ export class ProblemInfoPanel {
     private getWebviewContent(problem: Problem): string {
 		const stylesMainUri = this.getMediaFileUri('styles.css');
         const scriptMainUri = this.getMediaFileUri('script.js');
+        const scriptMathJaxUri = this.getMediaFileUri('mathjax.js');
         const playIconUri = this.getMediaFileUri('play_icon.png');
         
         return `
@@ -160,8 +161,7 @@ export class ProblemInfoPanel {
 
             <script src="${scriptMainUri}"></script>
             <script id="MathJax-script" async="" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-            <script src="https://ddo7jzca0m2vt.cloudfront.net/js/mathjax.js"></script>
-            
+            <script src="${scriptMathJaxUri}"></script>
             </body>
         </html>
         `;


### PR DESCRIPTION
## 작업 내용*
- `media` 폴더 내에 `mathjax.js`를 새로 추가합니다.
- `ProblemInfoPanel.getWebviewContent()` 메서드에서, 외부 JS 파일이 아닌 로컬 `media/mathjax.js`를 사용하도록 합니다.

## 작업 설명*
- `https://ddo7jzca0m2vt.cloudfront.net/js/mathjax.js`에서 MathJax 파일을 가져오고 있는데,
    vscode에서 `$`로 감싼 수식을 올바르게 표현하지 못하고 있습니다.
- 위 JS 파일 내 `renderActions` 속성을 제거하면 파싱한 BOJ 문제 설명 내 `$`나 `\(` 로 감싼 수식을 올바르게 표현합니다.
  - `renderActions` 내 `addCopyText()`는 문제를 복사할 때, 수식도 같이 복사되도록 하는 함수입니다.
  -  하지만 웹과 달리 vscode 상에는 올바르게 작동하지 않는 것 같습니다.

## 스크린샷

![스크린샷 2025-02-12 160611](https://github.com/user-attachments/assets/69b3af1a-69f9-4f1c-b449-49bd5628b556)
- 왼쪽: V1.0.6
- 오른쪽: 수정본 빌드 후 동일한 BOJ 문제를 열어본 상태
- [예시 문제 링크](https://www.acmicpc.net/problem/19539) - BOJ 19539 번