### PR TITLE
spawn 이 실행될 때 기본 위치를 워크스페이스 루트로 가도록 수정

### DIFF
--- a/src/utils/fileGenerator.ts
+++ b/src/utils/fileGenerator.ts
@@ -43,7 +43,7 @@ function getTemplateContent(fileName: string) {
     return extension && FILE_TEMPLATES[extension] ? FILE_TEMPLATES[extension] : '';
 }
 
-function getWorkSpaceRootFolder(): string | null {
+export function getWorkSpaceRootFolder(): string | null {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (workspaceFolders) {
         return workspaceFolders[0].uri.path;

--- a/src/utils/problemParser.ts
+++ b/src/utils/problemParser.ts
@@ -25,7 +25,6 @@ async function parseProblem(id: number): Promise<Problem> {
     const title = $("#problem_title").text().trim();
 
     // 문제 설명
-
     const descriptions: string[] = [];
     $('.problem-section').each((index, element) => {
         const problemText = $(element).find('.problem-text').text().trim();

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,4 +1,5 @@
-import { execSync, spawn } from 'child_process';
+import { execSync, spawn, SpawnOptionsWithoutStdio } from 'child_process';
+import { getWorkSpaceRootFolder } from './fileGenerator';
 
 class ChildProcess {
     private env: NodeJS.ProcessEnv = process.env;
@@ -16,9 +17,16 @@ class ChildProcess {
         }
     }
 
-    spawn(command: string, args: string[] = []){
+    spawn(command: string, args: string[] = [], options?: SpawnOptionsWithoutStdio){
+        const workSpaceRootFolder = getWorkSpaceRootFolder();
+        if (!workSpaceRootFolder) {
+            throw new Error('Fail to load work space root folder');
+        }
+
         return spawn(command, args, {
-            env: this.env
+            ...options,
+            env: this.env,
+            cwd: workSpaceRootFolder
         });
     }
 }


### PR DESCRIPTION
## 작업 내용*
- spawn 이 실행될 때 기본 위치를 워크스페이스 루트로 가도록 설정 추가


## 작업 설명*
### spawn
- spawn 은 기본으로 shell 을 사용하지 않기 때문에 실행했을 때 기본 위치가 맥을 기준으로 `/` 이다.
- spawn 인자인 options 에 `cwd: '경로'` 를 추가하여 기본 경로를 수정 할 수 있다.

## 스크린샷