### PR TITLE
윈도우 환경에서 워크스페이스 루트를 잘못 가져오는 문제 수정

### DIFF
--- a/src/utils/fileGenerator.ts
+++ b/src/utils/fileGenerator.ts
@@ -46,7 +46,7 @@ function getTemplateContent(fileName: string) {
 export function getWorkSpaceRootFolder(): string | null {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (workspaceFolders) {
-        return workspaceFolders[0].uri.path;
+        return workspaceFolders[0].uri.fsPath;
     } else {
         vscode.window.showErrorMessage('작업 영역이 없습니다. 폴더를 열고 문제를 생성해주세요.');
         return null;


### PR DESCRIPTION
## 작업 내용*
- ```fileGenerator.ts``` 파일의 ```getWorkSpaceRootFolder()``` 함수에서 ```uri.path``` 메소드를 ```uri.fsPath``` 메소드로 대체


## 작업 설명*
- 윈도우 환경에서 boj tester 사용 시 언어에 관계없이 time out이 뜨는 문제가 발생하였습니다.
- 확인해보니 경로를 잘못 가져와서 발생하는 문제인 것 같습니다.
- 워크스페이스 루트를 가져오는 함수를 확인해보니 최상위 경로에 '/' 가 포함되어 윈도우에서 경로를 확인하지 못하는 문제로 판단했습니다.
- path 메소드 대신 fsPath 메소드를 사용하여 경로 문제를 해결하였습니다.


## 스크린샷
### 발생 문제 스크린샷
![화면 캡처 2025-02-19 104149](https://github.com/user-attachments/assets/92a62f81-d960-4094-a2ac-7080fe42a7b3)

### path 메소드, fsPath 메소드 비교 스크린샷
![화면 캡처 2025-02-19 103936](https://github.com/user-attachments/assets/15455fd6-d346-4a1f-b6b7-86e327ea3067)
