### PR TITLE
언어별 컴파일 명령어 커스터마이징 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ BOJ Tester를 사용하려면 해당 프로그래밍 언어의 실행 환경이 
 BOJ Tester는 다음과 같은 설정을 제공합니다:
 
 * `BOJ-Tester.defaultLanguage`: 문제 파일 생성 시 사용할 기본 확장자 (예: py, java, cpp)
+* `BOJ-Tester.customCommands`: 언어별 원하는 커스텀 컴파일 명령어 작성  
+    * 컴파일 옵션을 직접 지정할 때 사용합니다 (예: `-std=c++17`)  
 ### 설정 방법
 1. BOJ Tester 사이드바 열기
 2. 사이드바의 제목 오른쪽에 위치한 톱니바퀴 아이콘 클릭

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boj-tester",
-  "version": "0.0.1",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boj-tester",
-      "version": "0.0.1",
+      "version": "1.0.10",
       "dependencies": {
         "axios": "^1.7.9",
         "cheerio": "^1.0.0"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
-        "@types/vscode": "^1.96.0",
+        "@types/vscode": "^1.95.0",
         "@typescript-eslint/eslint-plugin": "^8.17.0",
         "@typescript-eslint/parser": "^8.17.0",
         "@vscode/test-cli": "^0.0.10",
@@ -23,7 +23,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "vscode": "^1.96.0"
+        "vscode": "^1.95.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         }
       ]
     },
-
     "configuration": {
       "type": "object",
       "title": "BOJ Tester",
@@ -73,6 +72,18 @@
         "BOJ-Tester.defaultPath": {
           "type": "string",
           "description": "파일 생성 시 저장될 경로를 입력해주세요. 입력하지 않을 시 열려있는 워크스페이스의 루트 경로에 저장됩니다."
+        },
+        "BOJ-Tester.useCustomCommand": {
+          "type": "boolean",
+          "default": false,
+          "description": "직접 입력한 컴파일 명령어로 컴파일하고자 할 때 체크해주세요"
+        },
+        "BOJ-Tester.customCommands": {
+          "type": "object",
+          "default": {
+            "cpp": "g++ -std=c++17"
+          },
+          "description": "언어별 커스텀 컴파일 명령어 작성"
         }
       }
     }

--- a/src/utils/testCaseRunner.ts
+++ b/src/utils/testCaseRunner.ts
@@ -186,8 +186,21 @@ function compileAndRunC(filePath: string) {
 }
 
 function compileAndRun(filePath: string, compiler: 'gcc' | 'g++') {
+    const extension = filePath.split('.').pop()?.toLowerCase() as string;
     const outputFile = filePath.replace(/\.(c|cpp)$/, '');
-    execSync(`${compiler} "${filePath}" -o "${outputFile}"`);
+    const config = vscode.workspace.getConfiguration('BOJ-Tester');
+    const useCustomCommand = config.get<boolean>('useCustomCommand', false);
+    const customCommands = config.get<{ [key: string]: string }>('customCommands', {});
+
+
+    let compileCommand: string;
+    if (useCustomCommand && extension && customCommands[extension]) {
+        compileCommand = `${customCommands[extension]} "${filePath}" -o "${outputFile}"`;
+    } else {
+        compileCommand = `${compiler} "${filePath}" -o "${outputFile}"`;
+    }
+    
+    execSync(compileCommand);
     return childProcess.spawn(`${outputFile}`)
         .on('close', () => childProcess.spawn(process.platform === 'win32' ? 'del' : 'rm', [outputFile]));
 }


### PR DESCRIPTION
## 작업 내용*
- [Package.json] properties에 언어별 컴파일 명령어를 작성하는 object `customCommands`와 해당 명령어로 컴파일 수행 여부를 나타내는 `useCustomCommand` 속성을 추가했습니다.
- 이에 맞춰 compileAndRun 함수에서 후자의 속성이 true일 경우 가져온 커스텀 명령어로 컴파일을 수행하도록 처리했습니다.


## 작업 설명*
- customCommands 셋에 기본적으로 cpp 커스텀 명령어 `g++ -std=c++17`가 있습니다.
    - 유저들에게 기초적인 커스텀 명령어 입력 방식을 안내해주는 보기가 필요할 것 같아 미리 기입해놓았습니다.


## 스크린샷
1. 커스텀 명령어로 컴파일 수행 여부 토글
<img width="455" alt="image" src="https://github.com/user-attachments/assets/a05073b1-8a23-4abd-99e9-5043b9a5ed89" />

2. settings.json에서 커스텀 명령어 입력하는 object 
<img width="284" alt="image" src="https://github.com/user-attachments/assets/3150d4e2-dd35-46d3-8f7b-1e18c130c371" />
